### PR TITLE
update readme to refer to the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Import the plugin in your project by adding following configuration:
 ### build.gradle (Groovy DSL)
 ```groovy
 plugins {
-    id 'com.benjaminsproule.swagger' version '1.0.6'
+    id 'com.benjaminsproule.swagger' version '1.0.7'
 }
 ```
 
 ### build.gradle.kts (Kotlin DSL)
 ```kotlin
 plugins {
-    id("com.benjaminsproule.swagger") version "1.0.6"
+    id("com.benjaminsproule.swagger") version "1.0.7"
 }
 ```
 ## Gradle versions < 2.1


### PR DESCRIPTION
the current readme still refers to version 1.0.6 which contains a bug (see #129).
This PR update the readme to refer to the latest version 1.0.7.